### PR TITLE
Update to reflect the changes in the master branch of ES

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.18.5</elasticsearch.version>
+        <elasticsearch.version>0.19.0-SNAPSHOT</elasticsearch.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/elasticsearch/cloud/aws/blobstore/AbstractS3BlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/blobstore/AbstractS3BlobContainer.java
@@ -22,12 +22,12 @@ package org.elasticsearch.cloud.aws.blobstore;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
-import org.elasticsearch.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/network/Ec2NameResolver.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.cloud.aws.network;
 
+import com.google.common.io.Closeables;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.common.component.AbstractComponent;
-import org.elasticsearch.common.io.Closeables;
 import org.elasticsearch.common.network.NetworkService.CustomNameResolver;
 import org.elasticsearch.common.settings.Settings;
 

--- a/src/main/java/org/elasticsearch/cloud/aws/node/Ec2CustomNodeAttributes.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/node/Ec2CustomNodeAttributes.java
@@ -19,12 +19,12 @@
 
 package org.elasticsearch.cloud.aws.node;
 
+import com.google.common.collect.Maps;
+import com.google.common.io.Closeables;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
-import org.elasticsearch.common.collect.Maps;
 import org.elasticsearch.common.component.AbstractComponent;
-import org.elasticsearch.common.io.Closeables;
 import org.elasticsearch.common.settings.Settings;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
@@ -21,12 +21,12 @@ package org.elasticsearch.discovery.ec2;
 
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableMap;
-import org.elasticsearch.common.collect.ImmutableSet;
-import org.elasticsearch.common.collect.Lists;
-import org.elasticsearch.common.collect.Sets;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;

--- a/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import com.google.common.collect.ImmutableList;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
-import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.zen.ZenDiscovery;

--- a/src/main/java/org/elasticsearch/plugin/cloud/aws/CloudAwsPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/cloud/aws/CloudAwsPlugin.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.plugin.cloud.aws;
 
+import com.google.common.collect.Lists;
 import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.cloud.aws.AwsModule;
 import org.elasticsearch.cloud.aws.AwsS3Service;
-import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.Settings;


### PR DESCRIPTION
com.google.common.collect/io should be used instead of org.elasticsearch.common.collect.

I also took the liberty to update pom.xml to 0.19.0-SNAPSHOT, as I think it only makes sense that the master branch of the plugin repository works with the master branch of elasticsearch :)
