### PR TITLE
Catch AmazonClientExceptions to prevent connection loss

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.discovery.ec2;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.*;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -95,7 +96,14 @@ public class AwsEc2UnicastHostsProvider extends AbstractComponent implements Uni
     public List<DiscoveryNode> buildDynamicNodes() {
         List<DiscoveryNode> discoNodes = Lists.newArrayList();
 
-        DescribeInstancesResult descInstances = client.describeInstances(new DescribeInstancesRequest());
+        DescribeInstancesResult descInstances;
+        try {
+            descInstances = client.describeInstances(new DescribeInstancesRequest());
+        } catch (AmazonClientException e) {
+            logger.info("Exception while retrieving instance list from AWS API: {}", e.getMessage());
+            logger.debug("Full exception:", e);
+            return discoNodes;
+        }
 
         logger.trace("building dynamic unicast discovery nodes...");
         for (Reservation reservation : descInstances.getReservations()) {


### PR DESCRIPTION
If the AWS client throws an exception (e.g: because of a DNS failure) it will end up killing the rejoin thread and stop retrying which can lead to a node getting stuck unable to rejoin the cluster.
