### PR TITLE
Support group id in addition to group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ec2 discovery allows to use the ec2 APIs to perform automatic discovery (similar
 
 The following are a list of settings (prefixed with `discovery.ec2`) that can further control the discovery:
 
-* `groups`: Either a comma separated list or array based list of (security) groups. Only instances with the provided security groups will be used in the cluster discovery. (NOTE: You should provide the group NAME, not the group ID.)
+* `groups`: Either a comma separated list or array based list of (security) groups. Only instances with the provided security groups will be used in the cluster discovery. (NOTE: You could provide either group NAME or group ID.)
 * `host_type`: The type of host type to use to communicate with other instances. Can be one of `private_ip`, `public_ip`, `private_dns`, `public_dns`. Defaults to `private_ip`.
 * `availability_zones`: Either a comma separated list or array based list of availability zones. Only instances within the provided availability zones will be used in the cluster discovery.
 * `any_group`: If set to `false`, will require all security groups to be present for the instance to be used for the discovery. Defaults to `true`.

--- a/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
@@ -118,20 +118,27 @@ public class AwsEc2UnicastHostsProvider extends AbstractComponent implements Uni
                 if (!groups.isEmpty()) {
                     List<GroupIdentifier> instanceSecurityGroups = instance.getSecurityGroups();
                     ArrayList<String> securityGroupNames = new ArrayList<String>();
+                    ArrayList<String> securityGroupIds = new ArrayList<String>();
                     for (GroupIdentifier sg : instanceSecurityGroups) {
                         securityGroupNames.add(sg.getGroupName());
+                        securityGroupIds.add(sg.getGroupId());
                     }
                     if (bindAnyGroup) {
-                        if (Collections.disjoint(securityGroupNames, groups)) {
+                        // We check if we can find at least one group name or one group id in groups.
+                        if (Collections.disjoint(securityGroupNames, groups)
+                                && Collections.disjoint(securityGroupIds, groups)) {
                             logger.trace("filtering out instance {} based on groups {}, not part of {}", instance.getInstanceId(), instanceSecurityGroups, groups);
                             // continue to the next instance
                             continue;
                         }
                     } else {
                         if (!securityGroupNames.containsAll(groups)) {
-                            logger.trace("filtering out instance {} based on groups {}, does not include all of {}", instance.getInstanceId(), instanceSecurityGroups, groups);
-                            // continue to the next instance
-                            continue;
+                            // We did not succeed with group names. Let's try with group ids.
+                            if (!securityGroupIds.containsAll(groups)) {
+                                logger.trace("filtering out instance {} based on groups {}, does not include all of {}", instance.getInstanceId(), instanceSecurityGroups, groups);
+                                // continue to the next instance
+                                continue;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Based on issue #43, we want to support both notations:
- group name first
- group id if it does not work with group name

Closes #49.
