### PR TITLE
Allow per-repository endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The following settings are supported:
 * `bucket`: The name of the bucket to be used for snapshots. (Mandatory)
 * `region`: The region where bucket is located. Defaults to US Standard
 * `endpoint`: The endpoint to the S3 API. Defaults to AWS's default S3 endpoint. Note that setting a region overrides the endpoint setting.
+* `protocol`: The protocol to use (`http` or `https`). Defaults to `https`.
 * `base_path`: Specifies the path within bucket to repository data. Defaults to root directory.
 * `access_key`: The access key to use for authentication. Defaults to value of `cloud.aws.access_key`.
 * `secret_key`: The secret key to use for authentication. Defaults to value of `cloud.aws.secret_key`.
@@ -290,10 +291,16 @@ repositories:
         remote-bucket:
             bucket: <bucket in other region>
             region: <region>
+	external-bucket:
+	    bucket: <bucket>
+	    access_key: <access key>
+	    secret_key: <secret key>
+	    endpoint: <endpoint>
+	    protocol: <protocol>
 
 ```
 
-Replace all occurrences of `access_key`, `secret_key`, `bucket` and `region` with your settings. Please, note that the test will delete all snapshot/restore related files in the specified buckets.
+Replace all occurrences of `access_key`, `secret_key`, `endpoint`, `protocol`, `bucket` and `region` with your settings. Please, note that the test will delete all snapshot/restore related files in the specified buckets.
 
 To run test:
 

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.component.LifecycleComponent;
 public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
     AmazonS3 client();
 
-    AmazonS3 client(String endpoint, String region, String account, String key);
+    AmazonS3 client(String endpoint, String protocol, String region, String account, String key);
 
-    AmazonS3 client(String endpoint, String region, String account, String key, Integer maxRetries);
+    AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries);
 }

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -60,34 +60,32 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         String account = componentSettings.get("access_key", settings.get("cloud.account"));
         String key = componentSettings.get("secret_key", settings.get("cloud.key"));
 
-        return getClient(endpoint, account, key, null);
+        return getClient(endpoint, "https", account, key, null);
     }
 
     @Override
-    public AmazonS3 client(String endpoint, String region, String account, String key) {
-        return client(endpoint, region, account, key, null);
+    public AmazonS3 client(String endpoint, String protocol, String region, String account, String key) {
+        return client(endpoint, protocol, region, account, key, null);
     }
 
     @Override
-    public synchronized AmazonS3 client(String endpoint, String region, String account, String key, Integer maxRetries) {
-        if (endpoint == null) {
-            endpoint = getDefaultEndpoint();
-        }
-
-        if (region != null) {
+    public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries) {
+        if (region != null && endpoint == null) {
             endpoint = getEndpoint(region);
             logger.debug("using s3 region [{}], with endpoint [{}]", region, endpoint);
+        } else if (endpoint == null) {
+            endpoint = getDefaultEndpoint();
         }
         if (account == null || key == null) {
             account = componentSettings.get("access_key", settings.get("cloud.account"));
             key = componentSettings.get("secret_key", settings.get("cloud.key"));
         }
 
-        return getClient(endpoint, account, key, maxRetries);
+        return getClient(endpoint, protocol, account, key, maxRetries);
     }
 
 
-    private synchronized AmazonS3 getClient(String endpoint, String account, String key, Integer maxRetries) {
+    private synchronized AmazonS3 getClient(String endpoint, String protocol, String account, String key, Integer maxRetries) {
         Tuple<String, String> clientDescriptor = new Tuple<String, String>(endpoint, account);
         AmazonS3Client client = clients.get(clientDescriptor);
         if (client != null) {
@@ -95,8 +93,10 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         }
 
         ClientConfiguration clientConfiguration = new ClientConfiguration();
-        String protocol = componentSettings.get("protocol", "https").toLowerCase();
-        protocol = componentSettings.get("s3.protocol", protocol).toLowerCase();
+        if (protocol == null) {
+            protocol = "https";
+        }
+
         if ("http".equals(protocol)) {
             clientConfiguration.setProtocol(Protocol.HTTP);
         } else if ("https".equals(protocol)) {

--- a/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -80,6 +80,9 @@ public class S3Repository extends BlobStoreRepository {
         }
 
         String endpoint = repositorySettings.settings().get("endpoint", componentSettings.get("endpoint"));
+        String protocol = componentSettings.get("protocol", "https").toLowerCase();
+        protocol = componentSettings.get("s3.protocol", protocol).toLowerCase();
+        protocol = repositorySettings.settings().get("protocol", protocol);
 
         String region = repositorySettings.settings().get("region", componentSettings.get("region"));
         if (region == null) {
@@ -126,10 +129,10 @@ public class S3Repository extends BlobStoreRepository {
         this.chunkSize = repositorySettings.settings().getAsBytesSize("chunk_size", componentSettings.getAsBytesSize("chunk_size", new ByteSizeValue(100, ByteSizeUnit.MB)));
         this.compress = repositorySettings.settings().getAsBoolean("compress", componentSettings.getAsBoolean("compress", false));
 
-        logger.debug("using bucket [{}], region [{}], endpoint [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], max_retries [{}]",
-                bucket, region, endpoint, chunkSize, serverSideEncryption, bufferSize, maxRetries);
+        logger.debug("using bucket [{}], region [{}], endpoint [{}], protocol [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], max_retries [{}]",
+                bucket, region, endpoint, protocol, chunkSize, serverSideEncryption, bufferSize, maxRetries);
 
-        blobStore = new S3BlobStore(settings, s3Service.client(endpoint, region, repositorySettings.settings().get("access_key"), repositorySettings.settings().get("secret_key"), maxRetries), bucket, region, serverSideEncryption, bufferSize, maxRetries);
+        blobStore = new S3BlobStore(settings, s3Service.client(endpoint, protocol, region, repositorySettings.settings().get("access_key"), repositorySettings.settings().get("secret_key"), maxRetries), bucket, region, serverSideEncryption, bufferSize, maxRetries);
         String basePath = repositorySettings.settings().get("base_path", null);
         if (Strings.hasLength(basePath)) {
             BlobPath path = new BlobPath();

--- a/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -45,13 +45,13 @@ public class TestAwsS3Service extends InternalAwsS3Service {
     }
 
     @Override
-    public synchronized AmazonS3 client(String endpoint, String region, String account, String key) {
-        return cachedWrapper(super.client(endpoint, region, account, key));
+    public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key) {
+        return cachedWrapper(super.client(endpoint, protocol, region, account, key));
     }
 
     @Override
-    public synchronized AmazonS3 client(String region, String account, String key, Integer maxRetries) {
-        return cachedWrapper(super.client(region, account, key, maxRetries));
+    public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries) {
+        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {


### PR DESCRIPTION
With this patch, the S3 endpoint is no longer a global setting. This allows creating repositories on AWS s3 and others to S3-compatible services, without doing cluster restarts between snapshots.

```
$ curl -X PUT 'http://localhost:9200/_snapshot/test' -d '{
    "type":"s3",
    "settings":{
        "bucket":"hello",
        "endpoint":"my-s3.example.com",
        "access_key":"access key here",
        "secret_key":"it's a secret"
    }
}'
```

I couldn't make this work completely on elasticsearch master (snapshot creation API call properly makes s3 requests but in the end does not respond. Might be an issue with my setup). However I have successfully tried [the same patch](https://github.com/brutasse/elasticsearch-cloud-aws/compare/es-1.3...repo-endpoint-1.3) with ES 1.3 and the es-1.3 branch of this repository. Snapshotting and restoring to [pithos](http://github.com/exoscale/pithos), our S3 implementation at @exoscale, worked beautifully.
