### PR TITLE
Update AWS Java SDK to 1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `cloud.aws.region` can be set to a region and will automatically use the rel
 * `ap-southeast-2`
 * `ap-northeast` (`ap-northeast-1`)
 * `eu-west` (`eu-west-1`)
+* `eu-central` (`eu-central-1`)
 * `sa-east` (`sa-east-1`).
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <elasticsearch.version>2.0.0-SNAPSHOT</elasticsearch.version>
         <lucene.version>5.0.0</lucene.version>
         <lucene.maven.version>5.0.0-snapshot-1637347</lucene.maven.version>
-        <amazonaws.version>1.7.13</amazonaws.version>
+        <amazonaws.version>1.9.4</amazonaws.version>
         <tests.output>onerror</tests.output>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -121,6 +121,8 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
                 endpoint = "ec2.ap-northeast-1.amazonaws.com";
             } else if (region.equals("eu-west") || region.equals("eu-west-1")) {
                 endpoint = "ec2.eu-west-1.amazonaws.com";
+            } else if (region.equals("eu-central") || region.equals("eu-central-1")) {
+                endpoint = "ec2.eu-central-1.amazonaws.com";
             } else if (region.equals("sa-east") || region.equals("sa-east-1")) {
                 endpoint = "ec2.sa-east-1.amazonaws.com";
             } else {

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -171,6 +171,10 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             return "s3-eu-west-1.amazonaws.com";
         } else if ("eu-west-1".equals(region)) {
             return "s3-eu-west-1.amazonaws.com";
+        } else if ("eu-central".equals(region)) {
+            return "s3.eu-central-1.amazonaws.com";
+        } else if ("eu-central-1".equals(region)) {
+            return "s3.eu-central-1.amazonaws.com";
         } else if ("sa-east".equals(region)) {
             return "s3-sa-east-1.amazonaws.com";
         } else if ("sa-east-1".equals(region)) {

--- a/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -110,6 +110,10 @@ public class S3Repository extends BlobStoreRepository {
                     region = "EU";
                 } else if ("eu-west-1".equals(regionSetting)) {
                     region = "EU";
+                } else if ("eu-central".equals(regionSetting)) {
+                    region = "eu-central-1";
+                } else if ("eu-central-1".equals(regionSetting)) {
+                    region = "eu-central-1";
                 } else if ("sa-east".equals(regionSetting)) {
                     region = "sa-east-1";
                 } else if ("sa-east-1".equals(regionSetting)) {


### PR DESCRIPTION
The update itself is trivial, additionally this adds the mapping of the `eu-central`/`eu-central-1` region names so that one can use the new Frankfurt region.
