### PR TITLE
Use only the S3 and EC2 parts of the AWS Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,20 +96,15 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
             <version>${amazonaws.version}</version>
             <scope>compile</scope>
-            <exclusions>
-                <!-- jackson is optional -->
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-core-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${amazonaws.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- We need to explicitly set the common codec version since aws-java-sdk pulls the wrong version -->

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -19,7 +19,9 @@
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-                <include>com.amazonaws:aws-java-sdk</include>
+                <include>com.amazonaws:aws-java-sdk-core</include>
+                <include>com.amazonaws:aws-java-sdk-ec2</include>
+                <include>com.amazonaws:aws-java-sdk-s3</include>
                 <include>commons-codec:commons-codec</include>
             </includes>
         </dependencySet>


### PR DESCRIPTION
Since 1.9.0 the AWS SDK is available not just as a big blob, but also split into per-service modules. As the elasticsearch-cloud-aws plugin only requires s3 and ec2 it shouldn't pull in all other parts.

This reduces the size of the release artifact from ~17M to ~5M.

Note that this depends on #137, but is based on master now (i.e. it won't compile :D)
