### PR TITLE
Use the undeprecated 'install' form when invoking bin/plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for the unicast discovery mechanism and add S3 repositories.
 In order to install the plugin, run: 
 
 ```sh
-bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.4.0
+bin/plugin install elasticsearch/elasticsearch-cloud-aws/2.4.0
 ```
 
 You need to install a version matching your Elasticsearch version:


### PR DESCRIPTION
'-install' was deprecated in https://github.com/elasticsearch/elasticsearch/issues/3112
