### PR TITLE
Add support for path_style_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The following settings are supported:
 * `server_side_encryption`: When set to `true` files are encrypted on server side using AES256 algorithm. Defaults to `false`.
 * `buffer_size`: Minimum threshold below which the chunk is uploaded using a single request. Beyond this threshold, the S3 repository will use the [AWS Multipart Upload API](http://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html) to split the chunk into several parts, each of `buffer_size` length, and to upload each part in its own request. Note that positionning a buffer size lower than `5mb` is not allowed since it will prevents the use of the Multipart API and may result in upload errors. Defaults to `5mb`.
 * `max_retries`: Number of retries in case of S3 errors. Defaults to `3`.
+* `path_style_access`: activate path style access for [virtual hosting of buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html). Defaults to `false`.
 
 The S3 repositories are using the same credentials as the rest of the AWS services provided by this plugin (`discovery`).
 See [Generic Configuration](#generic-configuration) for details.

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -26,6 +26,7 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.collect.Tuple;
@@ -137,6 +138,13 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             );
         }
         client = new AmazonS3Client(credentials, clientConfiguration);
+
+        boolean pathStyleAccess = componentSettings.getAsBoolean("path_style_access", false);
+        pathStyleAccess = componentSettings.getAsBoolean("s3.path_style_access", pathStyleAccess);
+
+        if (pathStyleAccess) {
+            client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(pathStyleAccess));
+        }
 
         if (endpoint != null) {
             client.setEndpoint(endpoint);

--- a/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -384,7 +384,23 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTest {
         }
     }
 
-     private void assertRepositoryIsOperational(Client client, String repository) {
+    /**
+     * For feature request #124: https://github.com/elasticsearch/elasticsearch-cloud-aws/issues/124
+     */
+    @Test
+    public void testPathStyleAccess_124() {
+        Client client = client();
+        logger.info("-->  creating s3 repository with path style access");
+        PutRepositoryResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
+                .setType("s3").setSettings(ImmutableSettings.settingsBuilder()
+                                .put("base_path", basePath)
+                                .put("path_style_access", true)
+                ).get();
+        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        assertRepositoryIsOperational(client, "test-repo");
+    }
+
+    private void assertRepositoryIsOperational(Client client, String repository) {
         createIndex("test-idx-1");
         ensureGreen();
 


### PR DESCRIPTION
Add a new option `path_style_access` for S3 buckets. It adds support for path style access for [virtual hosting of buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).
Defaults to `false`.

Closes #124.