### PR TITLE
Separate proxy traffic for ec2 and s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ cloud:
         proxy_port: 8083
 ```
 
+You can also set different proxies for `ec2` and `s3`:
+
+```
+cloud:
+    aws:
+        s3:
+            proxy_host: proxy1.company.com
+            proxy_port: 8083
+        ec2:
+            proxy_host: proxy2.company.com
+            proxy_port: 8083
+```
 
 ### Region
 

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -76,8 +76,10 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
         String key = settings.get("cloud.aws.secret_key", settings.get("cloud.key"));
 
         String proxyHost = settings.get("cloud.aws.proxy_host");
+        proxyHost = settings.get("cloud.aws.ec2.proxy_host", proxyHost);
         if (proxyHost != null) {
             String portString = settings.get("cloud.aws.proxy_port", "80");
+            portString = settings.get("cloud.aws.ec2.proxy_port", portString);
             Integer proxyPort;
             try {
                 proxyPort = Integer.parseInt(portString, 10);

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -104,8 +104,10 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         }
 
         String proxyHost = settings.get("cloud.aws.proxy_host");
+        proxyHost = settings.get("cloud.aws.s3.proxy_host", proxyHost);
         if (proxyHost != null) {
             String portString = settings.get("cloud.aws.proxy_port", "80");
+            portString = settings.get("cloud.aws.s3.proxy_port", portString);
             Integer proxyPort;
             try {
                 proxyPort = Integer.parseInt(portString, 10);

--- a/src/test/java/org/elasticsearch/repositories/s3/S3ProxiedSnapshotRestoreOverHttpsTest.java
+++ b/src/test/java/org/elasticsearch/repositories/s3/S3ProxiedSnapshotRestoreOverHttpsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.repositories.s3;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+
+/**
+ * This will only run if you define in your `elasticsearch.yml` file a s3 specific proxy
+ * cloud.aws.s3.proxy_host: mys3proxy.company.com
+ * cloud.aws.s3.proxy_port: 8080
+ */
+public class S3ProxiedSnapshotRestoreOverHttpsTest extends AbstractS3SnapshotRestoreTest {
+
+    private boolean proxySet = false;
+
+    @Override
+    public Settings nodeSettings(int nodeOrdinal) {
+        Settings settings = super.nodeSettings(nodeOrdinal);
+        String proxyHost = settings.get("cloud.aws.s3.proxy_host");
+        proxySet = proxyHost != null;
+        return settings;
+    }
+
+    @Before
+    public void checkProxySettings() {
+        assumeTrue("we are expecting proxy settings in elasticsearch.yml file", proxySet);
+    }
+
+}


### PR DESCRIPTION
Based on PR #178 by @paul-e-cooley. Thanks Paul!

In addition to:

```yaml
cloud:
    aws:
        protocol: https
        proxy_host: proxy1.company.com
        proxy_port: 8083
```

You can also set different proxies for `ec2` and `s3`:

```yaml
cloud:
    aws:
        s3:
            proxy_host: proxy1.company.com
            proxy_port: 8083
        ec2:
            proxy_host: proxy2.company.com
            proxy_port: 8083
```

PR rebased on master and lastest changes about component settings removal.
Documentation added.
Changes in tests. If a proxy is provided we run the tests, otherwise we ignore the test.

Closes #177.