### PR TITLE
Add EC2/S3 Signer API setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ The `cloud.aws.region` can be set to a region and will automatically use the rel
 * `sa-east` (`sa-east-1`)
 * `cn-north` (`cn-north-1`)
 
+
+### EC2/S3 Signer API
+
+If you are using a compatible EC2 or S3 service, they might be using an older API to sign the requests.
+You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer` and `cloud.aws.s3.signer`)
+with the right signer to use. Defaults to `AWS4SignerType`.
+
+
 ## EC2 Discovery
 
 ec2 discovery allows to use the ec2 APIs to perform automatic discovery (similar to multicast in non hostile multicast environments). Here is a simple sample configuration:

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -86,6 +86,17 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
             clientConfiguration.withProxyHost(proxyHost).setProxyPort(proxyPort);
         }
 
+        // #155: we might have 3rd party users using older EC2 API version
+        String awsSigner = settings.get("cloud.aws.ec2.signer", settings.get("cloud.aws.signer"));
+        if (awsSigner != null) {
+            logger.debug("using AWS API signer [{}]", awsSigner);
+            try {
+                AwsSigner.configureSigner(awsSigner, clientConfiguration);
+            } catch (ElasticsearchIllegalArgumentException e) {
+                logger.warn("wrong signer set for [cloud.aws.ec2.signer] or [cloud.aws.signer]: [{}]", awsSigner);
+            }
+        }
+
         AWSCredentialsProvider credentials;
 
         if (account == null && key == null) {

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.SignerFactory;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+
+public class AwsSigner {
+
+    private AwsSigner() {
+
+    }
+
+    /**
+     * Add a AWS API Signer.
+     * @param signer Signer to use
+     * @param configuration AWS Client configuration
+     * @throws ElasticsearchIllegalArgumentException if signer does not exist
+     */
+    public static void configureSigner(String signer, ClientConfiguration configuration)
+        throws ElasticsearchIllegalArgumentException {
+
+        if (signer == null) {
+            throw new ElasticsearchIllegalArgumentException("[null] signer set");
+        }
+
+        try {
+            // We check this signer actually exists in AWS SDK
+            // It throws a IllegalArgumentException if not found
+            SignerFactory.getSignerByTypeAndService(signer, null);
+            configuration.setSignerOverride(signer);
+        } catch (IllegalArgumentException e) {
+            throw new ElasticsearchIllegalArgumentException("wrong signer set [" + signer + "]");
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -125,6 +125,17 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
             clientConfiguration.setMaxErrorRetry(maxRetries);
         }
 
+        // #155: we might have 3rd party users using older S3 API version
+        String awsSigner = settings.get("cloud.aws.s3.signer", settings.get("cloud.aws.signer"));
+        if (awsSigner != null) {
+            logger.debug("using AWS API signer [{}]", awsSigner);
+            try {
+                AwsSigner.configureSigner(awsSigner, clientConfiguration);
+            } catch (ElasticsearchIllegalArgumentException e) {
+                logger.warn("wrong signer set for [cloud.aws.s3.signer] or [cloud.aws.signer]: [{}]", awsSigner);
+            }
+        }
+
         AWSCredentialsProvider credentials;
 
         if (account == null && key == null) {

--- a/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTest.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.aws;
+
+import com.amazonaws.ClientConfiguration;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
+import org.elasticsearch.test.ElasticsearchTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class AWSSignersTest extends ElasticsearchTestCase {
+
+    @Test
+    public void testSigners() {
+        assertThat(signerTester(null), is(false));
+        assertThat(signerTester("QueryStringSignerType"), is(true));
+        assertThat(signerTester("AWS3SignerType"), is(true));
+        assertThat(signerTester("AWS4SignerType"), is(true));
+        assertThat(signerTester("NoOpSignerType"), is(true));
+        assertThat(signerTester("UndefinedSigner"), is(false));
+    }
+
+    /**
+     * Test a signer configuration
+     * @param signer signer name
+     * @return true if successful, false otherwise
+     */
+    private boolean signerTester(String signer) {
+        try {
+            AwsSigner.configureSigner(signer, new ClientConfiguration());
+            return true;
+        } catch (ElasticsearchIllegalArgumentException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
If you are using a compatible EC2 or S3 service, they might be using an older API to sign the requests.

You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer` and `cloud.aws.s3.signer`) with the right signer to use.

Defaults to `AWS4SignerType`.

Supported today (time when this commit is done):

* `QueryStringSignerType`
* `AWS3SignerType`
* `AWS4SignerType`
* `NoOpSignerType`

Closes #155.