### PR TITLE
Fix non working update dynamic settings

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/Ec2Discovery.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cloud.aws.AwsEc2Service;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
+import org.elasticsearch.cluster.settings.ClusterDynamicSettings;
 import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.Inject;
@@ -47,7 +48,7 @@ public class Ec2Discovery extends ZenDiscovery {
     public Ec2Discovery(Settings settings, ClusterName clusterName, ThreadPool threadPool, TransportService transportService,
                         ClusterService clusterService, NodeSettingsService nodeSettingsService, ZenPingService pingService,
                         DiscoveryNodeService discoveryNodeService, AwsEc2Service ec2Service, DiscoverySettings discoverySettings,
-                        ElectMasterService electMasterService, DynamicSettings dynamicSettings,
+                        ElectMasterService electMasterService, @ClusterDynamicSettings DynamicSettings dynamicSettings,
                         Version version) {
         super(settings, clusterName, threadPool, transportService, clusterService, nodeSettingsService,
                 discoveryNodeService, pingService, electMasterService, discoverySettings, dynamicSettings);

--- a/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryUpdateSettingsITest.java
+++ b/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryUpdateSettingsITest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.ec2;
+
+
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.cloud.aws.AbstractAwsTest;
+import org.elasticsearch.cloud.aws.AbstractAwsTest.AwsTest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.junit.Test;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Just an empty Node Start test to check eveything if fine when
+ * starting.
+ * This test requires AWS to run.
+ */
+@AwsTest
+@ClusterScope(scope = Scope.TEST, numDataNodes = 0, numClientNodes = 0, transportClientRatio = 0.0)
+public class Ec2DiscoveryUpdateSettingsITest extends AbstractAwsTest {
+
+    @Test
+    public void testMinimumMasterNodesStart() {
+        Settings nodeSettings = settingsBuilder()
+                .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
+                .put("cloud.enabled", true)
+                .put("discovery.type", "ec2")
+                .build();
+        internalCluster().startNode(nodeSettings);
+
+        // We try to update minimum_master_nodes now
+        ClusterUpdateSettingsResponse response = client().admin().cluster().prepareUpdateSettings()
+                .setPersistentSettings(settingsBuilder().put("discovery.zen.minimum_master_nodes", 1))
+                .setTransientSettings(settingsBuilder().put("discovery.zen.minimum_master_nodes", 1))
+                .get();
+
+        Integer min = response.getPersistentSettings().getAsInt("discovery.zen.minimum_master_nodes", null);
+        assertThat(min, is(1));
+    }
+
+}


### PR DESCRIPTION
Described in https://github.com/elastic/elasticsearch/issues/10614, it's not possible with cloud discovery plugin to update dynamic settings anymore.

```sh
curl -XPUT localhost:9200/_cluster/settings -d '{
    "persistent" : {
        "discovery.zen.minimum_master_nodes" : 3
    },
    "transient" : {
        "discovery.zen.minimum_master_nodes" : 3
    }
}'
```

gives

```json
{"acknowledged":true,"persistent":{},"transient":{}}
```

This patch makes that working again.