### PR TITLE
Disable response metadata cache.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <amazonaws.version>1.9.23</amazonaws.version>
+        <amazonaws.version>1.9.34</amazonaws.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsEc2Service.java
@@ -62,6 +62,9 @@ public class AwsEc2Service extends AbstractLifecycleComponent<AwsEc2Service> {
         }
 
         ClientConfiguration clientConfiguration = new ClientConfiguration();
+        // the response metadata cache is only there for diagnostics purposes,
+        // but can force objects from every response to the old generation.
+        clientConfiguration.setResponseMetadataCacheSize(0);
         String protocol = settings.get("cloud.aws.protocol", "https").toLowerCase();
         protocol = settings.get("cloud.aws.ec2.protocol", protocol).toLowerCase();
         if ("http".equals(protocol)) {

--- a/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -89,6 +89,9 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent<AwsS3Servic
         }
 
         ClientConfiguration clientConfiguration = new ClientConfiguration();
+        // the response metadata cache is only there for diagnostics purposes,
+        // but can force objects from every response to the old generation.
+        clientConfiguration.setResponseMetadataCacheSize(0);
         if (protocol == null) {
             protocol = settings.get("cloud.aws.protocol", "https").toLowerCase();
             protocol = settings.get("cloud.aws.s3.protocol", protocol).toLowerCase();

--- a/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
@@ -258,6 +258,26 @@ public class AmazonS3Wrapper implements AmazonS3 {
     }
 
     @Override
+    public void setBucketReplicationConfiguration(String bucketName, BucketReplicationConfiguration configuration) throws AmazonServiceException, AmazonClientException {
+        delegate.setBucketReplicationConfiguration(bucketName, configuration);
+    }
+
+    @Override
+    public void setBucketReplicationConfiguration(SetBucketReplicationConfigurationRequest setBucketReplicationConfigurationRequest) throws AmazonServiceException, AmazonClientException {
+        delegate.setBucketReplicationConfiguration(setBucketReplicationConfigurationRequest);
+    }
+
+    @Override
+    public BucketReplicationConfiguration getBucketReplicationConfiguration(String bucketName) throws AmazonServiceException, AmazonClientException {
+        return delegate.getBucketReplicationConfiguration(bucketName);
+    }
+
+    @Override
+    public void deleteBucketReplicationConfiguration(String bucketName) throws AmazonServiceException, AmazonClientException {
+        delegate.deleteBucketReplicationConfiguration(bucketName);
+    }
+
+    @Override
     public PutObjectResult putObject(PutObjectRequest putObjectRequest) throws AmazonClientException, AmazonServiceException {
         return delegate.putObject(putObjectRequest);
     }


### PR DESCRIPTION
This cache is only used for diagnostic purposes, but can force objects from every response to the old generation.

Fixes #193