### PR TITLE
Do not embed and serialize AmazonClientExceptions

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/blobstore/DefaultS3OutputStream.java
@@ -112,7 +112,8 @@ public class DefaultS3OutputStream extends S3OutputStream {
                         is.reset();
                         retry++;
                     } else {
-                        throw new IOException("Unable to upload object " + getBlobName(), e);
+                        // Since ES 1.7, third party exceptions like AmazonClientException cannot be serialized and thus should not be embedded in IOException
+                        throw new IOException("Unable to upload object " + getBlobName() + " due to " + e.getClass().getSimpleName() + ": " + e.getMessage());
                     }
                 }
             }
@@ -150,7 +151,7 @@ public class DefaultS3OutputStream extends S3OutputStream {
         }
     }
 
-    private void initializeMultipart() {
+    private void initializeMultipart() throws IOException {
         int retry = 0;
         while ((retry <= getNumberOfRetries()) && (multipartId == null)) {
             try {
@@ -163,7 +164,9 @@ public class DefaultS3OutputStream extends S3OutputStream {
                 if (getBlobStore().shouldRetry(e) && retry < getNumberOfRetries()) {
                     retry++;
                 } else {
-                    throw e;
+                    // Since ES 1.7, third party exceptions like AmazonClientException cannot be serialized and thus should not be embedded in IOException
+                    throw new IOException("Unable to initialize multipart request for object " + getBlobName()
+                            + " due to " + e.getClass().getSimpleName() + ": " + e.getMessage());
                 }
             }
         }
@@ -194,7 +197,9 @@ public class DefaultS3OutputStream extends S3OutputStream {
                         retry++;
                     } else {
                         abortMultipart();
-                        throw e;
+                        // Since ES 1.7, third party exceptions like AmazonClientException cannot be serialized and thus should not be embedded in IOException
+                        throw new IOException("Unable to upload multipart request [" + multipartId + "] for object " + getBlobName()
+                                + " due to " + e.getClass().getSimpleName() + ": " + e.getMessage());
                     }
                 }
             }
@@ -217,7 +222,7 @@ public class DefaultS3OutputStream extends S3OutputStream {
 
     }
 
-    private void completeMultipart() {
+    private void completeMultipart() throws IOException {
         int retry = 0;
         while (retry <= getNumberOfRetries()) {
             try {
@@ -229,7 +234,9 @@ public class DefaultS3OutputStream extends S3OutputStream {
                     retry++;
                 } else {
                     abortMultipart();
-                    throw e;
+                    // Since ES 1.7, third party exceptions like AmazonClientException cannot be serialized and thus should not be embedded in IOException
+                    throw new IOException("Unable to complete multipart request [" + multipartId + "] for object " + getBlobName()
+                            + " due to " + e.getClass().getSimpleName() + ": " + e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
Since elastic/elasticsearch@a1d64922815c31cafe429a52a96f31c09dc7903a third party exceptions like `AmazonClientException` cannot be serialized and thus should not be embedded in `IOException`.

With the current behavior, `AmazonClientException` are embedded in `IOException` but a verification in [LocalTransportChannel](https://github.com/elastic/elasticsearch/blob/1.7/src/main/java/org/elasticsearch/transport/local/LocalTransportChannel.java#L89) throws an assertion error, making the test `AbstractS3SnapshotRestoreTest.assertRepositoryWithCustomCredentialsIsNotAccessibleByDefaultCredentials` hangs forever.
