### PR TITLE
Update aws-sdk-java to 1.10.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <amazonaws.version>1.9.34</amazonaws.version>
+        <amazonaws.version>1.10.11</amazonaws.version>
         <tests.jvms>1</tests.jvms>
     </properties>
 

--- a/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
@@ -579,4 +579,78 @@ public class AmazonS3Wrapper implements AmazonS3 {
     public boolean isRequesterPaysEnabled(String bucketName) throws AmazonServiceException, AmazonClientException {
         return delegate.isRequesterPaysEnabled(bucketName);
     }
+
+
+	@Override
+	public ObjectListing listNextBatchOfObjects(ListNextBatchOfObjectsRequest listNextBatchOfObjectsRequest)
+			throws AmazonClientException, AmazonServiceException {
+		return delegate.listNextBatchOfObjects(listNextBatchOfObjectsRequest);
+	}
+
+
+	@Override
+	public VersionListing listNextBatchOfVersions(ListNextBatchOfVersionsRequest listNextBatchOfVersionsRequest)
+			throws AmazonClientException, AmazonServiceException {
+		return delegate.listNextBatchOfVersions(listNextBatchOfVersionsRequest);
+	}
+
+
+	@Override
+	public Owner getS3AccountOwner(GetS3AccountOwnerRequest getS3AccountOwnerRequest)
+			throws AmazonClientException, AmazonServiceException {
+		return delegate.getS3AccountOwner(getS3AccountOwnerRequest);
+	}
+
+
+	@Override
+	public BucketLoggingConfiguration getBucketLoggingConfiguration(
+			GetBucketLoggingConfigurationRequest getBucketLoggingConfigurationRequest)
+					throws AmazonClientException, AmazonServiceException {
+		return delegate.getBucketLoggingConfiguration(getBucketLoggingConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketVersioningConfiguration getBucketVersioningConfiguration(
+			GetBucketVersioningConfigurationRequest getBucketVersioningConfigurationRequest)
+					throws AmazonClientException, AmazonServiceException {
+		return delegate.getBucketVersioningConfiguration(getBucketVersioningConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketLifecycleConfiguration getBucketLifecycleConfiguration(
+			GetBucketLifecycleConfigurationRequest getBucketLifecycleConfigurationRequest) {
+		return delegate.getBucketLifecycleConfiguration(getBucketLifecycleConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketCrossOriginConfiguration getBucketCrossOriginConfiguration(
+			GetBucketCrossOriginConfigurationRequest getBucketCrossOriginConfigurationRequest) {
+		return delegate.getBucketCrossOriginConfiguration(getBucketCrossOriginConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketTaggingConfiguration getBucketTaggingConfiguration(
+			GetBucketTaggingConfigurationRequest getBucketTaggingConfigurationRequest) {
+		return delegate.getBucketTaggingConfiguration(getBucketTaggingConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketNotificationConfiguration getBucketNotificationConfiguration(
+			GetBucketNotificationConfigurationRequest getBucketNotificationConfigurationRequest)
+					throws AmazonClientException, AmazonServiceException {
+		return delegate.getBucketNotificationConfiguration(getBucketNotificationConfigurationRequest);
+	}
+
+
+	@Override
+	public BucketReplicationConfiguration getBucketReplicationConfiguration(
+			GetBucketReplicationConfigurationRequest getBucketReplicationConfigurationRequest)
+					throws AmazonServiceException, AmazonClientException {
+		return delegate.getBucketReplicationConfiguration(getBucketReplicationConfigurationRequest);
+	}
 }


### PR DESCRIPTION
Fixes #233

Amazon SDK v1.9.34 S3 functionality used by elasticsearch-cloud-aws no longer works after OpenJDK v1.8u60 due to JodaTime issues with timezone. More information here: https://github.com/aws/aws-sdk-java/issues/444