### PR TITLE
Added v2 AWS API signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ If you are using a compatible EC2 or S3 service, they might be using an older AP
 You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer` and `cloud.aws.s3.signer`)
 with the right signer to use. Defaults to `AWS4SignerType`.
 
+Use `AWS2SignerType` for google cloud store compatibility.
+
 
 ## EC2 Discovery
 

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsSigner.java
@@ -21,8 +21,17 @@ package org.elasticsearch.cloud.aws;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.SignerFactory;
+import com.amazonaws.services.s3.internal.S3Signer;
+
+import static com.amazonaws.auth.SignerFactory.registerSigner;
 
 public class AwsSigner {
+
+    private static final String VERSION_TWO_SIGNER = "AWS2SignerType";
+
+    static {
+        registerSigner(VERSION_TWO_SIGNER, S3Signer.class);
+    }
 
     private AwsSigner() {
 

--- a/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTest.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/AWSSignersTest.java
@@ -31,6 +31,7 @@ public class AWSSignersTest extends ElasticsearchTestCase {
     public void testSigners() {
         assertThat(signerTester(null), is(false));
         assertThat(signerTester("QueryStringSignerType"), is(true));
+        assertThat(signerTester("AWS2SignerType"), is(true));
         assertThat(signerTester("AWS3SignerType"), is(true));
         assertThat(signerTester("AWS4SignerType"), is(true));
         assertThat(signerTester("NoOpSignerType"), is(true));


### PR DESCRIPTION
Hi,

There some discussion on Signer types in https://github.com/elastic/elasticsearch-cloud-aws/issues/155#issuecomment-102975211

If we want to use AWS v2 compatibile service then we need to use `S3Signer`. Right now this is not possible as this type is not registered. However, if we register it then it starts working.

This was tested on 1.6 branch with google cloud storage.

Thanks,
Igor