### PR TITLE
Add paramter for path_style_access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <amazonaws.version>1.10.69</amazonaws.version>
+        <amazonaws.version>1.10.75</amazonaws.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/AwsS3Service.java
@@ -27,5 +27,5 @@ import org.elasticsearch.common.component.LifecycleComponent;
  */
 public interface AwsS3Service extends LifecycleComponent<AwsS3Service> {
     AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries,
-                    boolean useThrottleRetries);
+                    boolean useThrottleRetries, Boolean pathStyleAccess);
 }

--- a/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -114,6 +114,7 @@ public class S3Repository extends BlobStoreRepository {
             }
         }
 
+        boolean pathStyleAccess = repositorySettings.settings().getAsBoolean("path_style_access", componentSettings.getAsBoolean("path_style_access", false));
         boolean serverSideEncryption = repositorySettings.settings().getAsBoolean("server_side_encryption", componentSettings.getAsBoolean("server_side_encryption", false));
         ByteSizeValue bufferSize = repositorySettings.settings().getAsBytesSize("buffer_size", componentSettings.getAsBytesSize("buffer_size", null));
         Integer maxRetries = repositorySettings.settings().getAsInt("max_retries", componentSettings.getAsInt("max_retries", 3));
@@ -126,7 +127,7 @@ public class S3Repository extends BlobStoreRepository {
                 bucket, region, endpoint, protocol, chunkSize, serverSideEncryption, bufferSize, maxRetries, useThrottleRetries);
 
         blobStore = new S3BlobStore(settings, s3Service.client(endpoint, protocol, region, repositorySettings.settings().get("access_key"),
-                repositorySettings.settings().get("secret_key"), maxRetries, useThrottleRetries), bucket, region, serverSideEncryption, bufferSize, maxRetries);
+                repositorySettings.settings().get("secret_key"), maxRetries, useThrottleRetries, true/*TODO*/), bucket, region, serverSideEncryption, bufferSize, maxRetries);
         String basePath = repositorySettings.settings().get("base_path", null);
         if (Strings.hasLength(basePath)) {
             BlobPath path = new BlobPath();

--- a/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/AmazonS3Wrapper.java
@@ -46,7 +46,6 @@ public class AmazonS3Wrapper implements AmazonS3 {
         this.delegate = delegate;
     }
 
-
     @Override
     public void setEndpoint(String endpoint) {
         delegate.setEndpoint(endpoint);
@@ -670,5 +669,45 @@ public class AmazonS3Wrapper implements AmazonS3 {
 			GetBucketReplicationConfigurationRequest getBucketReplicationConfigurationRequest)
 					throws AmazonServiceException, AmazonClientException {
 		return delegate.getBucketReplicationConfiguration(getBucketReplicationConfigurationRequest);
+	}
+
+	@Override
+	public void setBucketAccelerateConfiguration(
+			SetBucketAccelerateConfigurationRequest setBucketAccelerateConfigurationRequest) {
+		delegate.setBucketAccelerateConfiguration(setBucketAccelerateConfigurationRequest);
+	}
+
+	@Override
+	public BucketAccelerateConfiguration getBucketAccelerateConfiguration(
+			GetBucketAccelerateConfigurationRequest getBucketAccelerateConfigurationRequest) {
+		return delegate.getBucketAccelerateConfiguration(getBucketAccelerateConfigurationRequest);
+	}
+
+	@Override
+	public BucketAccelerateConfiguration getBucketAccelerateConfiguration(String bucketName) {
+		return delegate.getBucketAccelerateConfiguration(bucketName);
+	}
+
+	@Override
+	public void setBucketAccelerateConfiguration(String bucketName,
+			BucketAccelerateConfiguration accelerateConfiguration) {
+		delegate.setBucketAccelerateConfiguration(bucketName, accelerateConfiguration);
+	}
+	
+	@Override
+	public ListObjectsV2Result listObjectsV2(String arg0) throws AmazonClientException, AmazonServiceException {
+		return delegate.listObjectsV2(arg0);
+	}
+
+	@Override
+	public ListObjectsV2Result listObjectsV2(ListObjectsV2Request arg0)
+			throws AmazonClientException, AmazonServiceException {
+		return delegate.listObjectsV2(arg0);
+	}
+
+	@Override
+	public ListObjectsV2Result listObjectsV2(String arg0, String arg1)
+			throws AmazonClientException, AmazonServiceException {
+		return delegate.listObjectsV2(arg0, arg1);
 	}
 }

--- a/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
+++ b/src/test/java/org/elasticsearch/cloud/aws/TestAwsS3Service.java
@@ -40,8 +40,8 @@ public class TestAwsS3Service extends InternalAwsS3Service {
 
     @Override
     public synchronized AmazonS3 client(String endpoint, String protocol, String region, String account, String key, Integer maxRetries,
-                                        boolean useThrottleRetries) {
-        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries, useThrottleRetries));
+                                        boolean useThrottleRetries, Boolean pathStyleAccess) {
+        return cachedWrapper(super.client(endpoint, protocol, region, account, key, maxRetries, useThrottleRetries, pathStyleAccess));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {

--- a/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -197,7 +197,7 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTest {
             bucket.get("region", settings.get("repositories.s3.region")),
             bucket.get("access_key", settings.get("cloud.aws.access_key")),
             bucket.get("secret_key", settings.get("cloud.aws.secret_key")),
-            null, randomBoolean());
+            null, randomBoolean(), false);
 
     String bucketName = bucket.get("bucket");
 	logger.info("--> verify encryption for bucket [{}], prefix [{}]", bucketName, basePath);
@@ -461,7 +461,7 @@ abstract public class AbstractS3SnapshotRestoreTest extends AbstractAwsTest {
             // We check that settings has been set in elasticsearch.yml integration test file
             // as described in README
             assertThat("Your settings in elasticsearch.yml are incorrects. Check README file.", bucketName, notNullValue());
-            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(endpoint, protocol, region, accessKey, secretKey, null, randomBoolean());
+            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(endpoint, protocol, region, accessKey, secretKey, null, randomBoolean(), false);
             try {
                 ObjectListing prevListing = null;
                 //From http://docs.amazonwebservices.com/AmazonS3/latest/dev/DeletingMultipleObjectsUsingJava.html


### PR DESCRIPTION
Added parameter for path_style_access that exists in newer versions of elastic since we need it for our storage that do not support the bucketname as prefix to the the endpoint.